### PR TITLE
Mount /sys/fs/cgroup into the container

### DIFF
--- a/newrelic-sysmond.service
+++ b/newrelic-sysmond.service
@@ -6,7 +6,7 @@ EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "docker history johanneswuerbach/newrelic-sysmond >/dev/null || docker pull johanneswuerbach/newrelic-sysmond"
 ExecStartPre=/bin/sh -c "docker inspect newrelic-sysmond >/dev/null && docker rm -f newrelic-sysmond || true"
-ExecStart=/usr/bin/docker run --rm --name newrelic-sysmond -e NEW_RELIC_LICENSE_KEY=YOUR_NEW_RELIC_KEY -e CUSTOM_HOSTNAME=%H -v /var/run/docker.sock:/var/run/docker.sock johanneswuerbach/newrelic-sysmond
+ExecStart=/usr/bin/docker run --rm --name newrelic-sysmond -e NEW_RELIC_LICENSE_KEY=YOUR_NEW_RELIC_KEY -e CUSTOM_HOSTNAME=%H -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /var/run/docker.sock:/var/run/docker.sock johanneswuerbach/newrelic-sysmond
 ExecStopPost=-/usr/bin/docker stop newrelic-sysmond
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
This is on CoreOS in order to collect container metrics.  Without the cgroup volume mount,, got "error: Cannot access cgroup for XX containers".